### PR TITLE
Verbose opt fix

### DIFF
--- a/src/fdw.py
+++ b/src/fdw.py
@@ -45,13 +45,15 @@ class ConstantForeignDataWrapper(ForeignDataWrapper):
             self.dataset = options['fdw_dataset']
             self.table = options['fdw_table']
             self.convertToTz = options.get('fdw_convert_tz')
-            self.verbose = options.get('fdw_verbose')
 
             # Set SQL dialect
             self.setOptionSqlDialect(options.get('fdw_sql_dialect'))
 
             # Set grouping option
             self.setOptionGroupBy(options.get('fdw_group'))
+
+            # Set verbose option
+            self.setOptionVerbose(options.get('fdw_verbose'))
 
             # Set casting rules
             self.setOptionCasting(options.get('fdw_casting'))
@@ -126,6 +128,18 @@ class ConstantForeignDataWrapper(ForeignDataWrapper):
             return
 
         self.groupBy = False
+
+    def setOptionVerbose(self, verbose):
+        """
+            Set a flag `self.verbose` as `True` if `verbose` contains the string 'true'
+            Otherwise, set it as `False`
+        """
+
+        if verbose == 'true':
+            self.verbose = True
+            return
+
+        self.verbose = False
 
     def setOptionCasting(self, cactingRules):
         """

--- a/src/fdw.py
+++ b/src/fdw.py
@@ -46,14 +46,14 @@ class ConstantForeignDataWrapper(ForeignDataWrapper):
             self.table = options['fdw_table']
             self.convertToTz = options.get('fdw_convert_tz')
 
+            # Set verbose option
+            self.setOptionVerbose(options.get('fdw_verbose'))
+
             # Set SQL dialect
             self.setOptionSqlDialect(options.get('fdw_sql_dialect'))
 
             # Set grouping option
             self.setOptionGroupBy(options.get('fdw_group'))
-
-            # Set verbose option
-            self.setOptionVerbose(options.get('fdw_verbose'))
 
             # Set casting rules
             self.setOptionCasting(options.get('fdw_casting'))


### PR DESCRIPTION
Bugfix:

**Current behavior:**
When the flag `fdw_verbose` is used with any non empty string (including `'false'`), the verbose mode is activated.

**Expected behavior:**
Verbose mode is activated only when `fdw_verbose` contains `'true'`

**New behavior:**
Verbose mode is activated only when `fdw_verbose` contains `'true'`
