### PR TITLE
Bump Google dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except(IOError, ImportError):
 
 setup(
     name='bigquery-fdw',
-    version='1.8',
+    version='1.9',
     description='BigQuery Foreign Data Wrapper for PostgreSQL',
     long_description=long_description,
     author='Gabriel Bordeaux',
@@ -19,7 +19,6 @@ setup(
     package_dir={'bigquery_fdw': 'src'},
     # external dependencies
     install_requires=[
-        'argparse',
         'google-cloud-bigquery==2.31.0',
         'google-auth==2.3.3',
         'google-auth-oauthlib==0.4.6',


### PR DESCRIPTION
Creating a new released following https://github.com/gabfl/bigquery_fdw/pull/22/commits/eaf68b19b6f9cd99e70cadc7788b1ea586bf14eb#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7:

Versions changes:
 - google-cloud-bigquery: 2.6.2 -> 2.31.0
 - google-auth: 1.24.0 -> 2.3.3
 - google-auth-oauthlib: 0.4.2 -> 0.4.6
