### PR TITLE
Add support for PostgreSQL 13 and 14, upgrade dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9']
-        postgresql-version: ['10', '11', '12', '14', '14']
+        postgresql-version: ['10', '11', '12', '13', '14']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9']
-        postgresql-version: ['10', '11', '12']
+        postgresql-version: ['10', '11', '12', '14', '14']
 
     steps:
       - uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
           sudo apt-get install --yes python3-setuptools python${{ matrix.python-version }}-dev make gcc
       - name: Clone and compile Multicorn
         run: |
-          git clone git://github.com/gabfl/Multicorn.git /opt/Multicorn
+          git clone https://github.com/pgsql-io/multicorn2.git /opt/Multicorn
           cd /opt/Multicorn
           sudo mkdir -p /usr/share/doc/postgresql-doc-${{ matrix.postgresql-version }} /usr/lib/postgresql/${{ matrix.postgresql-version }}/lib/bitcode/
           sudo chmod 777 /usr/share/doc/postgresql-doc-${{ matrix.postgresql-version }} /usr/lib/postgresql/${{ matrix.postgresql-version }}/lib/ /usr/share/postgresql/${{ matrix.postgresql-version }}/extension/ /usr/lib/postgresql/${{ matrix.postgresql-version }}/lib/bitcode/

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pip3 install bigquery-fdw
 Major dependencies installed automatically during the installation process:
 
  - [Google Cloud BigQuery](https://pypi.org/project/google-cloud-bigquery/)
- - [Multicorn](htthttps://github.com/pgsql-io/multicorn2)
+ - [Multicorn](https://github.com/pgsql-io/multicorn2)
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,8 @@ It allows to write queries in PostgreSQL SQL syntax using a foreign table. It su
 
 ## Requirements
 
- - PostgreSQL >= 9.5 up to 12
+ - PostgreSQL >= 9.5 up to 14
  - Python >= 3.4
-
-Currently, PostgreSQL 13 and 14 are unsupported by the dependency Multicorn (see [here](https://github.com/Segfault-Inc/Multicorn/issues/269) and [here](https://github.com/Segfault-Inc/Multicorn/issues/261)). Some forks of Multicorn seem to add support for these versions and are referenced in the GitHub issues linked.
-
-## ⚠️ Migrating to version 1.8 from versions 1.7 and below
-
-Starting with version 1.8, the `fdw_key` option is deprecated and replaced with a default environment variable. See [Authentication](#Authentication).
 
 ## Get started
 
@@ -43,21 +37,20 @@ You need to install the following dependencies:
 
 ```bash
 # Install required packages
-apt-get update
-apt-get install --yes postgresql-server-dev-12 python3-setuptools python3-dev make gcc git
+apt update
+apt install -y postgresql-server-dev-14 python3-setuptools python3-dev make gcc git
 ```
 
-For PostgresSQL 9.X, install `postgresql-server-dev-9.X` instead of `postgresql-server-dev-12`.
-
-All PostgreSQL versions from 9.2 to 12 should be supported. Building Multicorn against PostgreSQL 13 is currently not working properly (as of 1/21/2013).
+All PostgreSQL versions from 9.2 to 14 should be supported.
 
 #### Installation
 
 ```bash
 # Install Multicorn
-# gabfl/Multicorn is a fork of Segfault-Inc/Multicorn that adds better support for Python3.
-# You may chose to build against the original project instead.
-git clone git://github.com/gabfl/Multicorn.git && cd Multicorn
+# pgsql-io/multicorn2 is a fork of Segfault-Inc/Multicorn that adds support for PostgreSQL 13/14.
+# Alternatively, up to PostgreSQL 12, you can use gabfl/Multicorn that adds better support for Python3.
+# You may also choose to build against the original project instead.
+git clone https://github.com/pgsql-io/multicorn2.git Multicorn && cd Multicorn
 make && make install
 
 # Install bigquery_fdw
@@ -67,7 +60,7 @@ pip3 install bigquery-fdw
 Major dependencies installed automatically during the installation process:
 
  - [Google Cloud BigQuery](https://pypi.org/project/google-cloud-bigquery/)
- - [Multicorn](https://github.com/Segfault-Inc/Multicorn)
+ - [Multicorn](htthttps://github.com/pgsql-io/multicorn2)
 
 ## Authentication
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -51,7 +51,7 @@ Time: 3.992s (3 seconds)
 ## What is in the image?
 
 The docker images comes with:
- - PostgreSQL 12 installed
- - [Multicorn](https://github.com/gabfl/Multicorn) installed and compiled
+ - PostgreSQL 14 installed
+ - [Multicorn](https://github.com/pgsql-io/multicorn2) installed and compiled
  - All the packages required by bigquery_fdw
  - The setup.sql file comes pre-loaded with the foreign table `bigquery-public-data.usa_names.usa_1910_current` to test queries.

--- a/docs/test_client.md
+++ b/docs/test_client.md
@@ -14,7 +14,7 @@ bq_client_test --query "SELECT count(*) FROM my_dataset.my_table"
 
 ## Example
 
-```
+```bash
 $ export GOOGLE_APPLICATION_CREDENTIALS="/path/to/key.json"
 $ bq_client_test --query "SELECT count(*) FROM my_dataset.my_table"
 
@@ -24,4 +24,9 @@ $ bq_client_test --query "SELECT count(*) FROM my_dataset.my_table"
 <google.cloud.bigquery.job.QueryJob object at 0x10c863c18>
  * Query results:
 Row((21215,), {'f0_': 0})
+```
+
+You can also test against BigQuery public datasets with:
+```bash
+bq_client_test --query "SELECT * FROM bigquery-public-data.usa_names.usa_1910_current WHERE year = 2017 AND number > 1000 LIMIT 5;"
 ```

--- a/sample_sql/query.sql
+++ b/sample_sql/query.sql
@@ -2,5 +2,6 @@
 
 SELECT *
 FROM usa_names
-WHERE year = 2017 AND
-      number > 1000 LIMIT 5;
+WHERE year = 2017
+      AND number > 1000
+LIMIT 5;

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except(IOError, ImportError):
 
 setup(
     name='bigquery-fdw',
-    version='1.9',
+    version='2.0',
     description='BigQuery Foreign Data Wrapper for PostgreSQL',
     long_description=long_description,
     author='Gabriel Bordeaux',
@@ -19,9 +19,9 @@ setup(
     package_dir={'bigquery_fdw': 'src'},
     # external dependencies
     install_requires=[
-        'google-cloud-bigquery==2.31.0',
-        'google-auth==2.3.3',
-        'google-auth-oauthlib==0.4.6',
+        'google-cloud-bigquery==3.2.0',
+        'google-auth==2.8.0',
+        'google-auth-oauthlib==0.5.2',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Changelog:
 - Release new version 2.0
 - Add support for PostgreSQL 13 and 14
 - Updated Docker image with PostgreSQL 14

In depth:
 - Upgrade google dependenciesL
   + `oogle-cloud-bigquery==3.2.0`
   + `google-auth==2.8.0`
   + `google-auth-oauthlib==0.5.2`
 - Replace https://github.com/gabfl/Multicorn with https://github.com/pgsql-io/multicorn2 to add support for PostgreSQL 13 and 14