### PR TITLE
Add testing against PostgreSQL 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install PostgreSQL manually
         run: |
           sudo apt-get remove --purge postgresql*
-          echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | sudo tee -a /etc/apt/sources.list.d/pgdg.list
+          echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main 15" | sudo tee -a /etc/apt/sources.list.d/pgdg.list
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
           sudo apt-key add -
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9']
-        postgresql-version: ['10', '11', '12', '13', '14']
+        postgresql-version: ['10', '11', '12', '13', '14', '15']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Add testing against PostgreSQL 15

As per https://wiki.postgresql.org/wiki/Apt/FAQ#I_want_to_try_the_beta_version_of_the_next_PostgreSQL_release

```
echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | sudo tee -a /etc/apt/sources.list.d/pgdg.list
```

Was replaced with:

```
echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main 15" | sudo tee -a /etc/apt/sources.list.d/pgdg.list
```

It can be reverted back to the old value once Postgres 15 is out of beta.