### PR TITLE
Bump Google Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -U pip
+          pip uninstall protobuf
           pip install pycodestyle codecov pytest
           python setup.py install
       - name: Display Python dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
           pip install -U pip
           pip install pycodestyle codecov pytest
           python setup.py install
+      - name: Display Python dependencies
+        run: |
+          pip3 freeze
       - name: Run pycodestyle
         run: |
           pycodestyle --exclude=venv --ignore=E501 .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -U pip
-          pip uninstall protobuf
           pip install pycodestyle codecov pytest
           python setup.py install
       - name: Display Python dependencies

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 try:
     import pypandoc
     long_description = pypandoc.convert_file('README.md', 'rst')
-except(IOError, ImportError):
+except (IOError, ImportError):
     long_description = open('README.md').read()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'google-auth==2.8.0',
         # 'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
-        'protobuf==3.19.0',  # Forcing version for google-cloud-bigquery
+        'protobuf==3.20.1',  # Forcing version for google-cloud-bigquery
         'grpcio==1.48.1',  # Forcing version for google-cloud-bigquery
         'grpcio-status==1.48.1',  # Forcing version for google-cloud-bigquery
     ],

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'google-auth==2.8.0',
         # 'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
-        'protobuf==3.15.0',  # Forcing version for google-cloud-bigquery
+        'protobuf==3.19.0',  # Forcing version for google-cloud-bigquery
         'grpcio==1.48.1',  # Forcing version for google-cloud-bigquery
         'grpcio-status==1.48.1',  # Forcing version for google-cloud-bigquery
     ],

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     # external dependencies
     install_requires=[
         'google-cloud-bigquery==3.3.2',
-        'google-auth==2.9.0',
+        'google-auth==2.9.1',
         # 'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
         'protobuf==3.20.1',  # Forcing version for google-cloud-bigquery

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except(IOError, ImportError):
 
 setup(
     name='bigquery-fdw',
-    version='2.0',
+    version='2.1',
     description='BigQuery Foreign Data Wrapper for PostgreSQL',
     long_description=long_description,
     author='Gabriel Bordeaux',
@@ -19,8 +19,8 @@ setup(
     package_dir={'bigquery_fdw': 'src'},
     # external dependencies
     install_requires=[
-        'google-cloud-bigquery==3.2.0',
-        'google-auth==2.8.0',
+        'google-cloud-bigquery==3.3.2',
+        'google-auth==2.11.0,
         'google-auth-oauthlib==0.5.2',
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     # external dependencies
     install_requires=[
         'google-cloud-bigquery==3.3.2',
-        # 'google-auth==2.10.0',
         'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
         'protobuf==3.20.1',  # Forcing version for google-cloud-bigquery

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'google-cloud-bigquery==3.3.2',
         'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
-        'protobuf==4.21.2',  # Forcing version for google-cloud-bigquery
+        'protobuf==4.21.1',  # Forcing version for google-cloud-bigquery
         'grpcio==1.48.1',  # Forcing version for google-cloud-bigquery
         'grpcio-status==1.48.1',  # Forcing version for google-cloud-bigquery
     ],

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     # external dependencies
     install_requires=[
         'google-cloud-bigquery==3.3.2',
-        'google-auth==2.9.1',
+        'google-auth==2.10.0',
         # 'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
         'protobuf==3.20.1',  # Forcing version for google-cloud-bigquery

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,6 @@ setup(
         # 'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
         'protobuf==3.20.1',  # Forcing version for google-cloud-bigquery
-        'grpcio==1.48.1',  # Forcing version for google-cloud-bigquery
-        'grpcio-status==1.48.1',  # Forcing version for google-cloud-bigquery
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     # external dependencies
     install_requires=[
         'google-cloud-bigquery==3.3.2',
-        'google-auth==2.11.0,
+        'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_dir={'bigquery_fdw': 'src'},
     # external dependencies
     install_requires=[
-        'google-cloud-bigquery==3.3.0',
+        'google-cloud-bigquery==3.3.1',
         # 'google-cloud-bigquery==3.3.2',
         'google-auth==2.8.0',
         # 'google-auth==2.11.0',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ setup(
         'google-cloud-bigquery==3.3.2',
         'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
-        'protobuf==4.21.5',  # Dependency for google-cloud-bigquery
+        'protobuf==4.21.5',  # Forcing version for google-cloud-bigquery
+        'grpcio==1.48.1',  # Forcing version for google-cloud-bigquery
+        'grpcio-status==1.48.1',  # Forcing version for google-cloud-bigquery
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'google-auth==2.8.0',
         # 'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
-        # 'protobuf==4.21.5',  # Forcing version for google-cloud-bigquery
+        'protobuf==3.12.0',  # Forcing version for google-cloud-bigquery
         'grpcio==1.48.1',  # Forcing version for google-cloud-bigquery
         'grpcio-status==1.48.1',  # Forcing version for google-cloud-bigquery
     ],

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'google-cloud-bigquery==3.3.2',
         'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
+        'protobuf==4.21.5',  # Dependency for google-cloud-bigquery
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,10 @@ setup(
     package_dir={'bigquery_fdw': 'src'},
     # external dependencies
     install_requires=[
-        'google-cloud-bigquery==3.3.2',
-        'google-auth==2.11.0',
+        'google-cloud-bigquery==3.2.0',
+        # 'google-cloud-bigquery==3.3.2',
+        'google-auth==2.8.0',
+        # 'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
         # 'protobuf==4.21.5',  # Forcing version for google-cloud-bigquery
         'grpcio==1.48.1',  # Forcing version for google-cloud-bigquery

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setup(
     package_dir={'bigquery_fdw': 'src'},
     # external dependencies
     install_requires=[
-        'google-cloud-bigquery==3.3.1',
-        # 'google-cloud-bigquery==3.3.2',
+        # 'google-cloud-bigquery==3.3.1',
+        'google-cloud-bigquery==3.3.2',
         'google-auth==2.8.0',
         # 'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,8 @@ setup(
     package_dir={'bigquery_fdw': 'src'},
     # external dependencies
     install_requires=[
-        # 'google-cloud-bigquery==3.3.1',
         'google-cloud-bigquery==3.3.2',
-        'google-auth==2.8.0',
+        'google-auth==2.9.0',
         # 'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
         'protobuf==3.20.1',  # Forcing version for google-cloud-bigquery

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'google-auth==2.8.0',
         # 'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
-        'protobuf==3.12.0',  # Forcing version for google-cloud-bigquery
+        'protobuf==3.15.0',  # Forcing version for google-cloud-bigquery
         'grpcio==1.48.1',  # Forcing version for google-cloud-bigquery
         'grpcio-status==1.48.1',  # Forcing version for google-cloud-bigquery
     ],

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ setup(
         # 'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
         'protobuf==3.20.1',  # Forcing version for google-cloud-bigquery
+        'grpcio==1.48.1',  # Forcing version for google-cloud-bigquery
+        'grpcio-status==1.48.1',  # Forcing version for google-cloud-bigquery
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ setup(
     # external dependencies
     install_requires=[
         'google-cloud-bigquery==3.3.2',
-        'google-auth==2.10.0',
-        # 'google-auth==2.11.0',
+        # 'google-auth==2.10.0',
+        'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
         'protobuf==3.20.1',  # Forcing version for google-cloud-bigquery
         'grpcio==1.48.1',  # Forcing version for google-cloud-bigquery

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_dir={'bigquery_fdw': 'src'},
     # external dependencies
     install_requires=[
-        'google-cloud-bigquery==3.2.0',
+        'google-cloud-bigquery==3.3.0',
         # 'google-cloud-bigquery==3.3.2',
         'google-auth==2.8.0',
         # 'google-auth==2.11.0',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'google-cloud-bigquery==3.3.2',
         'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
-        'protobuf==4.21.5',  # Forcing version for google-cloud-bigquery
+        # 'protobuf==4.21.5',  # Forcing version for google-cloud-bigquery
         'grpcio==1.48.1',  # Forcing version for google-cloud-bigquery
         'grpcio-status==1.48.1',  # Forcing version for google-cloud-bigquery
     ],

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'google-cloud-bigquery==3.3.2',
         'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
-        'protobuf==3.20.1',  # Forcing version for google-cloud-bigquery
+        'protobuf==4.21.1',  # Forcing version for google-cloud-bigquery
         'grpcio==1.48.1',  # Forcing version for google-cloud-bigquery
         'grpcio-status==1.48.1',  # Forcing version for google-cloud-bigquery
     ],

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'google-cloud-bigquery==3.3.2',
         'google-auth==2.11.0',
         'google-auth-oauthlib==0.5.2',
-        'protobuf==4.21.1',  # Forcing version for google-cloud-bigquery
+        'protobuf==4.21.2',  # Forcing version for google-cloud-bigquery
         'grpcio==1.48.1',  # Forcing version for google-cloud-bigquery
         'grpcio-status==1.48.1',  # Forcing version for google-cloud-bigquery
     ],


### PR DESCRIPTION
Update Google dependencies:
 - `google-cloud-bigquery` from `3.2.0` to `3.3.2`
 - `google-auth` from `2.8.0 ` to `2.11.0`

Force the following dependencies versions:
 - `protobuf` to `4.21.1`
 - `grpcio` to `1.48.1`
 - `grpcio-status` to `1.48.1`
