### PR TITLE
Add support for PostGIS data types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except (IOError, ImportError):
 
 setup(
     name='bigquery-fdw',
-    version='2.1',
+    version='2.2',
     description='BigQuery Foreign Data Wrapper for PostgreSQL',
     long_description=long_description,
     author='Gabriel Bordeaux',

--- a/src/fdw.py
+++ b/src/fdw.py
@@ -416,9 +416,10 @@ class ConstantForeignDataWrapper(ForeignDataWrapper):
         operators = ['=', '<', '>', '<=', '>=', '!=', '<>', 'LIKE', 'NOT LIKE']
 
         # Mapping between multicorn operators and BigQuery operators
-        mapping = {}
-        mapping['~~'] = 'LIKE'
-        mapping['!~~'] = 'NOT LIKE'
+        mapping = {
+            '~~': 'LIKE',
+            '!~~': 'NOT LIKE',
+        }
 
         if operator in operators:  # Operator is natively supported
             return operator

--- a/src/fdw.py
+++ b/src/fdw.py
@@ -76,6 +76,8 @@ class ConstantForeignDataWrapper(ForeignDataWrapper):
             datatype('date', 'DATE', 'DATE'),
             datatype('time without time zone', 'TIME', 'TIME'),
             datatype('timestamp without time zone', 'DATETIME', 'DATETIME'),
+            datatype('geometry', 'GEOGRAPHY', None),  # GEOGRAPHY does not exists in legacy SQL
+            datatype('geography', 'GEOGRAPHY', None),  # GEOGRAPHY does not exists in legacy SQL
         ]
 
     def setConversionRules(self):
@@ -441,7 +443,8 @@ class ConstantForeignDataWrapper(ForeignDataWrapper):
             if datatype.postgres == pgDatatype:  # If the PostgreSQL data type matches the known data type
                 # Returns equivalent BigQuery data type
                 if dialect == 'legacy':
-                    return datatype.bq_legacy
+                    if datatype.bq_legacy:  # If there is a matching type
+                        return datatype.bq_legacy
                 else:
                     return datatype.bq_standard
 

--- a/src/unittest/test_fdw.py
+++ b/src/unittest/test_fdw.py
@@ -63,7 +63,7 @@ class Test(unittest.TestCase):
             self.assertIsInstance(datatype, tuple)
             self.assertIsInstance(datatype.postgres, str)
             self.assertIsInstance(datatype.bq_standard, str)
-            self.assertIsInstance(datatype.bq_legacy, str)
+            assert isinstance(datatype.bq_legacy, str) or datatype.bq_legacy is None
 
     def test_setConversionRules(self):
         self.fdw.setConversionRules()


### PR DESCRIPTION
Add support for PostgreSQL's PostGIS `geometry` and `geography` data types, both mapped to BigQuery's `GEOGRAPHY` datatypes