### PR TITLE
Bump packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           pip install -U pip
           pip install pycodestyle coverage pytest pypandoc
-          python setup.py install
+          pip3 install .
       - name: Display Python dependencies
         run: |
           pip3 freeze

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
         'google-auth==2.27.0',
         'google-auth-oauthlib==1.2.0',
         # 'protobuf==4.21.8',  # Forcing version for google-cloud-bigquery
-        # 'grpcio==1.53.2',  # Forcing version for google-cloud-bigquery
-        # 'grpcio-status==1.50.0',  # Forcing version for google-cloud-bigquery
+        # 'grpcio==1.60.1',  # Forcing version for google-cloud-bigquery
+        # 'grpcio-status==1.60.1',  # Forcing version for google-cloud-bigquery
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_dir={'bigquery_fdw': 'src'},
     # external dependencies
     install_requires=[
-        'google-cloud-bigquery==3.172',
+        'google-cloud-bigquery==3.17.2',
         'google-auth==2.27.0',
         'google-auth-oauthlib==1.2.0',
         'protobuf==4.21.8',  # Forcing version for google-cloud-bigquery

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ setup(
         'google-cloud-bigquery==3.17.2',
         'google-auth==2.27.0',
         'google-auth-oauthlib==1.2.0',
-        'protobuf==4.21.8',  # Forcing version for google-cloud-bigquery
-        'grpcio==1.53.2',  # Forcing version for google-cloud-bigquery
-        'grpcio-status==1.50.0',  # Forcing version for google-cloud-bigquery
+        # 'protobuf==4.21.8',  # Forcing version for google-cloud-bigquery
+        # 'grpcio==1.53.2',  # Forcing version for google-cloud-bigquery
+        # 'grpcio-status==1.50.0',  # Forcing version for google-cloud-bigquery
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'google-auth==2.21.0',
         'google-auth-oauthlib==1.0.0',
         'protobuf==4.21.8',  # Forcing version for google-cloud-bigquery
-        'grpcio==1.53.0',  # Forcing version for google-cloud-bigquery
+        'grpcio==1.53.2',  # Forcing version for google-cloud-bigquery
         'grpcio-status==1.50.0',  # Forcing version for google-cloud-bigquery
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ setup(
     package_dir={'bigquery_fdw': 'src'},
     # external dependencies
     install_requires=[
-        'google-cloud-bigquery==3.11.2',
-        'google-auth==2.21.0',
-        'google-auth-oauthlib==1.0.0',
+        'google-cloud-bigquery==3.172',
+        'google-auth==2.27.0',
+        'google-auth-oauthlib==1.2.0',
         'protobuf==4.21.8',  # Forcing version for google-cloud-bigquery
         'grpcio==1.53.2',  # Forcing version for google-cloud-bigquery
         'grpcio-status==1.50.0',  # Forcing version for google-cloud-bigquery


### PR DESCRIPTION
 - Bump `google-*` packages
 - `protobuf` and `grpcio*` can now use default versions
 - Update install command for GH actions